### PR TITLE
p4plugin 5.0.0: Branches as streams

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,3 @@
 ---
 approvers:
-  - team-eng-velocity
-  - team-live-ops
-  - team-reliability-engineering
+  - nwx-automation

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,21 +2,8 @@
 # Please keep lists alphabetically, case-insensitive, sorted
 
 # These are lists of github usernames.
-# Yes, there's a special hell for us and we don't have a mapping system for GH->improbable and back, yet.
+# Yes, there's a special hell for us and we don't have a mapping system for GH->FLX and back, yet.
 aliases:
-  team-eng-velocity:
-    - DoomGerbil         # Sean Robertson
-    - filipVisko         # Filip Viskovic
-    - Helcaraxan         # Duco van Amstel
-    - PaulSonOfLars      # PaulSonOfLars
-  team-live-ops:
-    - LeadTimeNull       # Andreas Valentin Pedersen
-    - adamhosier         # Adam Hosier
-    - jared-improbable   # Jared Dixey-Hefty
-    - tenevdev           # Tencho Tenev
-    - Christopher-Steel  # Christopher George Steel
-  team-reliability-engineering:
-    - Christopher-Steel  # Christopher George Steel
-    - filipVisko         # Filip Viskovic
-    - LeadTimeNull       # Andreas Valentin Pedersen
-    - PaulSonOfLars      # PaulSonOfLars
+  nwx-automation:
+    - theokeeler
+    - JustinTime

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,4 +6,6 @@
 aliases:
   nwx-automation:
     - theokeeler
-    - JustinTime
+    - JustinTether
+    - dhausauer-flx
+    - ScottBrooks

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# Perforce Buildkite Plugin [![Build Status](https://travis-ci.com/improbable-eng/perforce-buildkite-plugin.svg?branch=master)](https://travis-ci.com/improbable-eng/perforce-buildkite-plugin)
-
 A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) that lets you check out code from [Perforce Version Control](https://www.perforce.com/products/helix-core) on Windows, Linux and macOS platforms.
 
 1. Configure at least `P4PORT` and `P4USER` (see examples below)
@@ -19,7 +17,7 @@ env:
 
 steps:
   plugins:
-    - improbable-eng/perforce: ~
+    - inflexiongames/perforce: ~
 ```
 
 ### Configuration via plugin
@@ -27,7 +25,7 @@ steps:
 ```yaml
 steps:
   plugins:
-    - improbable-eng/perforce:
+    - inflexiongames/perforce:
       p4port: perforce:1666
       p4user: username
 ```

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -5,7 +5,7 @@ set -eo pipefail
 if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true ]]; then
   echo "Workspace sharing enabled"
 
-  STREAM="${BUILDKITE_PLUGIN_PERFORCE_STREAM}"
+  STREAM="${BUILDKITE_BRANCH}"
   if [[ -z "${STREAM}" ]]; then
     echo "Error: You must use stream workspaces to enable shared workspaces" >&2
     exit 1
@@ -17,10 +17,10 @@ if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true ]]; then
   if [[ "${BUILDKITE_PLUGIN_PERFORCE_STREAM_SWITCHING}" == true ]]; then
     echo "Stream switching enabled"
     # Sanitize '//depot/stream-name' to 'depot'
-    SANITIZED_STREAM=$(echo $STREAM | python -c "import sys; print(sys.stdin.read().split('/')[2]);")
+    SANITIZED_STREAM=$(echo $STREAM | python -c "import sys; print(sys.stdin.read().split('/')[0]);")
   else # Create a directory per-stream
     # Sanitize '//depot/stream-name' to '__depot_stream-name'
-    SANITIZED_STREAM=$(echo $STREAM | python -c "import sys; print(sys.stdin.read().replace('/', '_'));")
+    SANITIZED_STREAM=$(echo $STREAM | python -c "import sys; print(sys.stdin.read().split('!')[0].replace('/', '_'));")
   fi
   # Instead of builds/<agent_number>/<pipeline>, checkout to builds/<stream_name>
   PERFORCE_CHECKOUT_PATH="${BUILDKITE_BUILD_CHECKOUT_PATH}/../../${SANITIZED_STREAM}"

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -3,6 +3,7 @@ set -eo pipefail
 
 echo "Starting pre-checkout hook"
 echo "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}"
+echo "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true
 
 # Allow sharing of perforce client workspaces for the same stream between pipelines
 if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true ]]; then

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -2,6 +2,7 @@
 set -eo pipefail
 
 echo "Starting pre-checkout hook"
+echo "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}"
 
 # Allow sharing of perforce client workspaces for the same stream between pipelines
 if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true ]]; then

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-echo "Starting pre-checkout hook"
-echo "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}"
 
 # Allow sharing of perforce client workspaces for the same stream between pipelines
 if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" = "yes" ]]; then

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -5,7 +5,7 @@ echo "Starting pre-checkout hook"
 echo "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}"
 
 # Allow sharing of perforce client workspaces for the same stream between pipelines
-if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == "yes" ]]; then
+if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" = "yes" ]]; then
   echo "Workspace sharing enabled"
 
   STREAM="${BUILDKITE_BRANCH}"
@@ -17,7 +17,7 @@ if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == "yes" ]]; then
     echo "Error: You cannot share stream workspaces when running more than one agent" >&2
     exit 1
   fi
-  if [[ "${BUILDKITE_PLUGIN_PERFORCE_STREAM_SWITCHING}" == "yes" ]]; then
+  if [[ "${BUILDKITE_PLUGIN_PERFORCE_STREAM_SWITCHING}" = "yes" ]]; then
     echo "Stream switching enabled"
     # Sanitize '//depot/stream-name' to 'depot'
     SANITIZED_STREAM=$(echo $STREAM | python -c "import sys; print(sys.stdin.read().split('/')[0]);")

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -3,10 +3,9 @@ set -eo pipefail
 
 echo "Starting pre-checkout hook"
 echo "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}"
-echo "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true
 
 # Allow sharing of perforce client workspaces for the same stream between pipelines
-if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true ]]; then
+if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == "yes" ]]; then
   echo "Workspace sharing enabled"
 
   STREAM="${BUILDKITE_BRANCH}"
@@ -18,7 +17,7 @@ if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true ]]; then
     echo "Error: You cannot share stream workspaces when running more than one agent" >&2
     exit 1
   fi
-  if [[ "${BUILDKITE_PLUGIN_PERFORCE_STREAM_SWITCHING}" == true ]]; then
+  if [[ "${BUILDKITE_PLUGIN_PERFORCE_STREAM_SWITCHING}" == "yes" ]]; then
     echo "Stream switching enabled"
     # Sanitize '//depot/stream-name' to 'depot'
     SANITIZED_STREAM=$(echo $STREAM | python -c "import sys; print(sys.stdin.read().split('/')[0]);")

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eo pipefail
 
+echo "Starting pre-checkout hook"
+
 # Allow sharing of perforce client workspaces for the same stream between pipelines
 if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true ]]; then
   echo "Workspace sharing enabled"

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 ---
 name: Perforce
 description: Checks out a perforce repository instead of git.
-author: https://github.com/ca-johnson
+author: https://github.com/inflexiongames
 configuration:
   properties:
     client_options:
@@ -19,9 +19,9 @@ configuration:
     parallel:
       type: string
     share_workspace:
-      type: bool
+      type: boolean
     stream_switching:
-      type: bool
+      type: boolean
     sync:
       type: array
     fingerprint:

--- a/plugin.yml
+++ b/plugin.yml
@@ -20,8 +20,6 @@ configuration:
       type: string
     share_workspace:
       type: bool
-    stream:
-      type: string
     stream_switching:
       type: bool
     sync:

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,6 +2,8 @@
 name: Perforce
 description: Checks out a perforce repository instead of git.
 author: https://github.com/inflexiongames
+requirements:
+  - p4
 configuration:
   properties:
     client_options:

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -1,11 +1,13 @@
 """
 Interact with buildkite as part of plugin hooks
 """
+from dataclasses import dataclass
 import os
 import sys
 import subprocess
 import re
 from datetime import datetime
+from typing import Dict, Optional, Tuple
 
 __ACCESS_TOKEN__ = os.environ['BUILDKITE_AGENT_ACCESS_TOKEN']
 # https://github.com/buildkite/cli/blob/e8aac4bedf34cd8084a3ae7a4ab7812c611d0310/local/run.go#L403
@@ -13,6 +15,9 @@ __LOCAL_RUN__ = os.environ['BUILDKITE_AGENT_NAME'] == 'local'
 
 __REVISION_METADATA__ = 'buildkite-perforce-revision'
 __REVISION_METADATA_DEPRECATED__ = 'buildkite:perforce:revision' # old metadata key, incompatible with `bk local run`
+
+__STREAM_ENV_VAR__ = "PERFORCE_PLUGIN_STREAM"
+__SHELF_ENV_VAR__ = "PERFORCE_PLUGIN_SHELF"
 
 def get_env():
     """Get env vars passed in via plugin config"""
@@ -25,7 +30,7 @@ def get_env():
             env[p4var] = plugin_value
     return env
 
-def list_from_env_array(var):
+def list_from_env_array(var, substitutions: Dict[str, callable]):
     """Read list of values from either VAR or VAR_0, VAR_1 etc"""
     result = os.environ.get(var, [])
     if result:
@@ -36,7 +41,10 @@ def list_from_env_array(var):
         elem = os.environ.get("%s_%d" % (var, i))
         if not elem:
             break
-        result.append(elem)
+        processed_elem = elem
+        for replacement, replacer in substitutions:
+            processed_elem = processed_elem.replace(replacement, replacer())
+        result.append(processed_elem)
         i += 1
 
     return result
@@ -45,8 +53,10 @@ def get_config():
     """Get configuration which will be passed directly to perforce.P4Repo as kwargs"""
     conf = {}
     conf['view'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_VIEW') or '//... ...'
-    conf['stream'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_STREAM')
-    conf['sync'] = list_from_env_array('BUILDKITE_PLUGIN_PERFORCE_SYNC')
+    conf['stream'] = get_stream_from_buildkite()
+    conf['sync'] = list_from_env_array('BUILDKITE_PLUGIN_PERFORCE_SYNC', {
+        "<stream>": get_stream_from_buildkite
+    })
     conf['parallel'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_PARALLEL') or 1
     conf['client_options'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_CLIENT_OPTIONS')
     conf['client_type'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_CLIENT_TYPE')
@@ -84,17 +94,49 @@ def set_metadata(key, value, overwrite=False):
         subprocess.call(['buildkite-agent', 'meta-data', 'set',  key, value])
         return True
 
+def set_environment_var(key, value):
+    """ Sets an env variable for the job. Uses buildkite-agent for resilience."""
+
+    if not __ACCESS_TOKEN__ or __LOCAL_RUN__:
+        # Cannot set env vars outside of buildkite context, including `bk local run`
+        return False
+
+    subprocess.call(['buildkite-agent', 'env', 'set', f'"{key}={value}"'])
+    return True
+
+@dataclass
+class StreamAndShelf:
+    stream: str
+    user_changelist: Optional[str]
+
+def get_stream_and_user_changelist() -> StreamAndShelf:
+    """Extract the stream and user changelist (if applicable) from the Buildkite Branch"""
+    branch = os.environ.get('BUILDKITE_BRANCH', '')
+
+    stream_shelf_pattern = r"(?<stream>[A-z_0-9-]+\/[A-z_0-9-]+)(?:!(?<shelf>[0-9]+))?"
+    matches_pattern = re.match(stream_shelf_pattern, branch)
+
+    stream = ""
+    user_changelist = None
+    if matches_pattern:
+        stream = f"//{matches_pattern.group('stream')}"
+        user_changelist = matches_pattern.group('shelf')
+
+    return StreamAndShelf(stream, user_changelist)
+
+
 def get_users_changelist():
     """Get the shelved changelist supplied by the user, if applicable"""
-    # Overrides the CL to unshelve via plugin config
-    # TODO: Remove this to discourage git-based pipelines that sync perforce
-    shelved_cl = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_SHELVED_CHANGE')
-    if shelved_cl:
-        return shelved_cl
+    user_changelist = get_stream_and_user_changelist().user_changelist
+    if user_changelist is not None:
+        set_environment_var(__SHELF_ENV_VAR__, user_changelist)
+    return user_changelist
 
-    branch = os.environ.get('BUILDKITE_BRANCH', '')
-    if branch.isdigit():
-        return branch
+def get_stream_from_buildkite():
+    """Get the name of the current stream from buildkite"""
+    stream = get_stream_and_user_changelist().stream
+    set_environment_var(__STREAM_ENV_VAR__, stream)
+    return stream
 
 def get_build_revision():
     """Get a p4 revision for the build from buildkite context"""

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -70,6 +70,7 @@ def get_config():
     conf['sync'] = list_from_env_array('BUILDKITE_PLUGIN_PERFORCE_SYNC', {
         "<stream>": get_stream_from_buildkite
     })
+    print(f"Processed sync: {conf['sync']}")
     conf['parallel'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_PARALLEL') or 1
     conf['client_options'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_CLIENT_OPTIONS')
     conf['client_type'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_CLIENT_TYPE')

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -46,6 +46,8 @@ def list_from_env_array(var, substitutions: Dict[str, callable] = None):
             for replacement, replacer in substitutions:
                 print(f"Replacing {replacement} with {replacer()}")
                 processed_elem = processed_elem.replace(replacement, replacer())
+        else:
+            print(f"No replacements for {var}")
         result.append(processed_elem)
         i += 1
 

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -44,6 +44,7 @@ def list_from_env_array(var, substitutions: Dict[str, callable] = None):
         processed_elem = elem
         if substitutions is not None:
             for replacement, replacer in substitutions:
+                print(f"Replacing {replacement} with {replacer()}")
                 processed_elem = processed_elem.replace(replacement, replacer())
         result.append(processed_elem)
         i += 1

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -55,6 +55,7 @@ def get_config():
     conf = {}
     conf['view'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_VIEW') or '//... ...'
     conf['stream'] = get_stream_from_buildkite()
+    print(f"Detected stream: {get_stream_from_buildkite()}")
     conf['sync'] = list_from_env_array('BUILDKITE_PLUGIN_PERFORCE_SYNC', {
         "<stream>": get_stream_from_buildkite
     })

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -43,6 +43,7 @@ def list_from_env_array(var, substitutions: Dict[str, callable] = None):
             break
         processed_elem = elem
         if substitutions is not None:
+            print(f"Replacing with replacers {substitutions}")
             for replacement, replacer in substitutions:
                 print(f"Replacing {replacement} with {replacer()}")
                 processed_elem = processed_elem.replace(replacement, replacer())

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -7,7 +7,7 @@ import sys
 import subprocess
 import re
 from datetime import datetime
-from typing import Dict, Optional, Tuple
+from typing import Callable, Dict, Optional, Tuple
 
 __ACCESS_TOKEN__ = os.environ['BUILDKITE_AGENT_ACCESS_TOKEN']
 # https://github.com/buildkite/cli/blob/e8aac4bedf34cd8084a3ae7a4ab7812c611d0310/local/run.go#L403
@@ -30,7 +30,7 @@ def get_env():
             env[p4var] = plugin_value
     return env
 
-def list_from_env_array(var, substitutions: Dict[str, callable] = None):
+def list_from_env_array(var, substitutions: Dict[str, Callable] = None):
     """Read list of values from either VAR or VAR_0, VAR_1 etc"""
     result = os.environ.get(var, [])
     print(f"Getting list for {var}")
@@ -38,7 +38,7 @@ def list_from_env_array(var, substitutions: Dict[str, callable] = None):
         processed_elem = result
         if substitutions is not None:
             print(f"Replacing with replacers {substitutions}")
-            for replacement, replacer in substitutions:
+            for replacement, replacer in substitutions.items():
                 print(f"Replacing {replacement} with {replacer()}")
                 processed_elem = processed_elem.replace(replacement, replacer())
         return [processed_elem] # convert single value to list
@@ -51,7 +51,7 @@ def list_from_env_array(var, substitutions: Dict[str, callable] = None):
         processed_elem = elem
         if substitutions is not None:
             print(f"Replacing with replacers {substitutions}")
-            for replacement, replacer in substitutions:
+            for replacement, replacer in substitutions.items():
                 print(f"Replacing {replacement} with {replacer()}")
                 processed_elem = processed_elem.replace(replacement, replacer())
         else:
@@ -66,7 +66,7 @@ def get_config():
     conf = {}
     conf['view'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_VIEW') or '//... ...'
     conf['stream'] = get_stream_from_buildkite()
-    print(f"Detected stream: {get_stream_from_buildkite()}")
+    print(f"Detected stream: {conf['stream']}")
     conf['sync'] = list_from_env_array('BUILDKITE_PLUGIN_PERFORCE_SYNC', {
         "<stream>": get_stream_from_buildkite
     })

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -34,7 +34,13 @@ def list_from_env_array(var, substitutions: Dict[str, callable] = None):
     """Read list of values from either VAR or VAR_0, VAR_1 etc"""
     result = os.environ.get(var, [])
     if result:
-        return [result] # convert single value to list
+        processed_elem = result
+        if substitutions is not None:
+            print(f"Replacing with replacers {substitutions}")
+            for replacement, replacer in substitutions:
+                print(f"Replacing {replacement} with {replacer()}")
+                processed_elem = processed_elem.replace(replacement, replacer())
+        return [processed_elem] # convert single value to list
 
     i = 0
     while True:

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -33,6 +33,7 @@ def get_env():
 def list_from_env_array(var, substitutions: Dict[str, callable] = None):
     """Read list of values from either VAR or VAR_0, VAR_1 etc"""
     result = os.environ.get(var, [])
+    print(f"Getting list for {var}")
     if result:
         processed_elem = result
         if substitutions is not None:

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -30,7 +30,7 @@ def get_env():
             env[p4var] = plugin_value
     return env
 
-def list_from_env_array(var, substitutions: Dict[str, callable]):
+def list_from_env_array(var, substitutions: Dict[str, callable] = None):
     """Read list of values from either VAR or VAR_0, VAR_1 etc"""
     result = os.environ.get(var, [])
     if result:
@@ -42,8 +42,9 @@ def list_from_env_array(var, substitutions: Dict[str, callable]):
         if not elem:
             break
         processed_elem = elem
-        for replacement, replacer in substitutions:
-            processed_elem = processed_elem.replace(replacement, replacer())
+        if substitutions is not None:
+            for replacement, replacer in substitutions:
+                processed_elem = processed_elem.replace(replacement, replacer())
         result.append(processed_elem)
         i += 1
 

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -33,13 +33,10 @@ def get_env():
 def list_from_env_array(var, substitutions: Dict[str, Callable] = None):
     """Read list of values from either VAR or VAR_0, VAR_1 etc"""
     result = os.environ.get(var, [])
-    print(f"Getting list for {var}")
     if result:
         processed_elem = result
         if substitutions is not None:
-            print(f"Replacing with replacers {substitutions}")
             for replacement, replacer in substitutions.items():
-                print(f"Replacing {replacement} with {replacer()}")
                 processed_elem = processed_elem.replace(replacement, replacer())
         return [processed_elem] # convert single value to list
 
@@ -50,12 +47,8 @@ def list_from_env_array(var, substitutions: Dict[str, Callable] = None):
             break
         processed_elem = elem
         if substitutions is not None:
-            print(f"Replacing with replacers {substitutions}")
             for replacement, replacer in substitutions.items():
-                print(f"Replacing {replacement} with {replacer()}")
                 processed_elem = processed_elem.replace(replacement, replacer())
-        else:
-            print(f"No replacements for {var}")
         result.append(processed_elem)
         i += 1
 
@@ -66,11 +59,9 @@ def get_config():
     conf = {}
     conf['view'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_VIEW') or '//... ...'
     conf['stream'] = get_stream_from_buildkite()
-    print(f"Detected stream: {conf['stream']}")
     conf['sync'] = list_from_env_array('BUILDKITE_PLUGIN_PERFORCE_SYNC', {
         "<stream>": get_stream_from_buildkite
     })
-    print(f"Processed sync: {conf['sync']}")
     conf['parallel'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_PARALLEL') or 1
     conf['client_options'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_CLIENT_OPTIONS')
     conf['client_type'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_CLIENT_TYPE')

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -107,6 +107,7 @@ def set_environment_var(key, value):
         return False
 
     subprocess.call(['buildkite-agent', 'env', 'set', f'"{key}={value}"'])
+    os.environ[key] = value
     return True
 
 @dataclass

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -113,7 +113,7 @@ def get_stream_and_user_changelist() -> StreamAndShelf:
     """Extract the stream and user changelist (if applicable) from the Buildkite Branch"""
     branch = os.environ.get('BUILDKITE_BRANCH', '')
 
-    stream_shelf_pattern = r"(?<stream>[A-z_0-9-]+\/[A-z_0-9-]+)(?:!(?<shelf>[0-9]+))?"
+    stream_shelf_pattern = r"(?P<stream>[A-z_0-9-]+\/[A-z_0-9-]+)(?:!(?P<shelf>[0-9]+))?"
     matches_pattern = re.match(stream_shelf_pattern, branch)
 
     stream = ""


### PR DESCRIPTION
Uses BUILDKITE_BRANCH as a stream spec (with special syntax for shelves) rather than taking in `stream` as a plugin arg, to facilitate better usage of streams/task streams within buildkite pipelines. Significant breaking change, thus the version bump.