### PR TITLE
feat: Add on-disk flag to detect interruption

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -30,3 +30,5 @@ configuration:
       type: string
     view:
       type: string
+    interrupted_flag:
+      type: string

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -70,6 +70,7 @@ def get_config():
     if 'BUILDKITE_PLUGIN_PERFORCE_ROOT' in os.environ and not __LOCAL_RUN__:
         raise Exception("Custom P4 root is for use in unit tests only")
     conf['root'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_ROOT') or os.environ.get('BUILDKITE_BUILD_CHECKOUT_PATH')
+    conf['interrupted_flag'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_INTERRUPTED_FLAG') or os.path.join(os.environ.get('BUILDKITE_BUILD_CHECKOUT_PATH'),'p4interrupted.flag')
 
     # Coerce view into pairs of [depot client] paths
     view_parts = conf['view'].split(' ')

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -1,10 +1,8 @@
 """
 Manage a perforce workspace in the context of a build machine
 """
-from functools import wraps
 import os
 import re
-import signal
 import socket
 import logging
 import sys


### PR DESCRIPTION
This adds a flag file for syncs and unshelve/print operations that indicates if an operation in progress. If this flag is visible outside those operations, it means the agent performing this sync was nongracefully interrupted during sync. This functionality doesn't change how this plugin behaves, but users of the plugin can consume it elsewhere and deal with their build agents accordingly (I suggest a `pre-bootstrap` hook to check for it and shut down your agent; Buildkite will show this as the agent refusing the job).