### PR TITLE
Feat/partitioned workspaces

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -169,7 +169,7 @@ class P4Repo:
             if prev_clientname != clientname:
                 need_full_clean = True
                 bless_version_file = os.path.join(self.root, "bless.version")
-                if self.client_type == "writeable":
+                if "readonly" not in self.client_type:
                     self.perforce.logger.warning("p4config last client was %s, flushing workspace to match" % prev_clientname)
                     self._flush_to_previous_client(client, prev_clientname)
                     need_full_clean = False

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -33,7 +33,7 @@ class P4Repo:
         self.sync_paths = sync or ['//...']
         assert isinstance(self.sync_paths, list)
         self.client_options = client_options or ''
-        self.client_type = client_type or 'writeable'
+        self.client_type = client_type or 'partitioned'
         self.parallel = parallel
         self.fingerprint = fingerprint or ''
 

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -228,6 +228,8 @@ class P4Repo:
             self.historical_interruption = True
         with open(self.interrupted_flag, 'w') as outfile:
             outfile.write("dirty")
+        with open(os.path.join(self.root, '.p4ignore'), 'a') as ignore_file:
+            ignore_file.write("p4interrupted.flag")
 
     def _delete_interrupted(self):
         """Remove the interruption marker, tracking that the sync process concluded as expected."""


### PR DESCRIPTION
Default to using partitioned workspaces https://portal.perforce.com/s/article/17297 for CI agent clients.

Partitioned clients are "partitioned" in that perforce does not maintain a havelist for clients of this type on the server, instead, the clients maintain a local havelist. Partitioned havelists do not get recorded in the journal and therefore do not get checkpointed either. This is a perfect (and intended) use case for frequent CI jobs. 

Our initial concern based on information from the perforce team was that partitioned clients do not support stream switching. This has either been fixed under the hood or was never the case, testing indicates partitioned clients can stream switch, sync and flush without issue.

**** also includes a fix to exclude the tombstone file from any p4 operations (p4 clean was deleting it too early in certain instances).