### PR TITLE
Rely on bless.version file for partitioned workspaces.

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -162,14 +162,14 @@ class P4Repo:
 
         if os.path.isfile(self.p4config):
             with open(self.p4config) as infile:
-                prev_clientname = next(line.split('=', 1)[-1]
-                    for line in infile.read().splitlines() # removes \n
-                    if line.startswith('P4CLIENT='))
+                prev_clientname = next(line.split('=', 1)[-1] for
+                                       line in infile.read().splitlines() if  # removes \n
+                                       line.startswith('P4CLIENT='))
             # p4 flush @client is only supported for writeable
             if prev_clientname != clientname:
                 need_full_clean = True
                 bless_version_file = os.path.join(self.root, "bless.version")
-                if "readonly" not in self.client_type:
+                if self.client_type == "writeable":
                     self.perforce.logger.warning("p4config last client was %s, flushing workspace to match" % prev_clientname)
                     self._flush_to_previous_client(client, prev_clientname)
                     need_full_clean = False
@@ -184,7 +184,7 @@ class P4Repo:
                             need_full_clean = False
                         else:
                             self.perforce.logger.warning("invalid bless.version format: %s. Expected format is stream@CL, e.g. //depot/main@123456" % blessed_version_string)
-                
+
                 if need_full_clean:
                     self.perforce.logger.warning("cleaning workspace to ensure have table is correctly populated. Due to lack of bless.version file in root and mismatched with previous clientname %s" % prev_clientname)
                     self.perforce.run_clean(['-a', '-d', '//...'])


### PR DESCRIPTION
This is effectively a revert of release 5.2.2. It turns out partitioned clients do not persist their metadata locally across VM boots meaning the `p4 flush` to the previous client does nothing. Revert back to relying on a bless.version file for partitioned clients.

...Shoulda read the doc strings the first time:
```
    def _flush_to_stream_and_changelist(self, current_client, prev_client_stream, prev_client_changelist):
        """
        Flush a new client to match existing workspace data from a previous client, using the CL and stream.
        
        This is needed for partitioned and read-only workspaces that can't directly use another client for flushing.
        """
        stream_switch = self.stream and prev_client_stream != self.stream
        if stream_switch:
            self.perforce.logger.info("previous client stream %s does not match %s, switching stream temporarily to flush" % (prev_client_stream, self.stream))
            current_client._stream = prev_client_stream
            self.perforce.save_client(current_client)

        self.perforce.run_flush(['//...@%s' % prev_client_changelist])

        if stream_switch:
            self.perforce.logger.info("switching stream back to %s" % self.stream)
            current_client._stream = self.stream
            self.perforce.save_client(current_client)
```